### PR TITLE
Update documentation on SSL support for Stats URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Notes: Works with HAProxy v 1.3 and above.
         <argument name="username" is-required="false" default-value=""/>
         <argument name="password" is-required="false" default-value=""/>
         <!--If the haproxy stats URI is SSL enabled, ie; HTTPS, use the below option -->
-        <argument name="use-ssl" is-required="false" default-value=""/>
+        <argument name="use-ssl" is-required="false" default-value="false"/>
 
         <!--proxy names you wish to monitor as a comma separated values. If empty all the proxies are monitored -->
         <argument name="proxynames" is-required="false" default-value=""/>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Notes: Works with HAProxy v 1.3 and above.
 
         <argument name="username" is-required="false" default-value=""/>
         <argument name="password" is-required="false" default-value=""/>
+        <!--If the haproxy stats URI is SSL enabled, ie; HTTPS, use the below option -->
+        <argument name="use-ssl" is-required="false" default-value="true"/>
 
         <!--proxy names you wish to monitor as a comma separated values. If empty all the proxies are monitored -->
         <argument name="proxynames" is-required="false" default-value=""/>

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Notes: Works with HAProxy v 1.3 and above.
 
         <argument name="username" is-required="false" default-value=""/>
         <argument name="password" is-required="false" default-value=""/>
-        <!--If the haproxy stats URI is SSL enabled, ie; HTTPS, use the below option -->
-        <argument name="use-ssl" is-required="false" default-value="true"/>
 
         <!--proxy names you wish to monitor as a comma separated values. If empty all the proxies are monitored -->
         <argument name="proxynames" is-required="false" default-value=""/>

--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ Notes: Works with HAProxy v 1.3 and above.
 
         <argument name="username" is-required="false" default-value=""/>
         <argument name="password" is-required="false" default-value=""/>
+        <!--If the haproxy stats URI is SSL enabled, ie; HTTPS, use the below option -->
+        <argument name="use-ssl" is-required="false" default-value="true"/>
 
         <!--proxy names you wish to monitor as a comma separated values. If empty all the proxies are monitored -->
         <argument name="proxynames" is-required="false" default-value=""/>
         <!--HA Proxy stats as a comma separated values to be excluded from monitoring -->
         <argument name="excludeStats" is-required="false" default-value="pid,iid,sid"/>
-        <argument name="metric-prefix" is-required="false" default-value="Custom Metrics|HAProxy|"/>
+        <!--Please ensure the Component ID is set
+        <argument name="metric-prefix" is-required="false" default-value="Server|Component:<<component_id>>|Custom Metrics|HAProxy|"/>
   ```
      
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Notes: Works with HAProxy v 1.3 and above.
         <argument name="username" is-required="false" default-value=""/>
         <argument name="password" is-required="false" default-value=""/>
         <!--If the haproxy stats URI is SSL enabled, ie; HTTPS, use the below option -->
-        <argument name="use-ssl" is-required="false" default-value="true"/>
+        <argument name="use-ssl" is-required="false" default-value=""/>
 
         <!--proxy names you wish to monitor as a comma separated values. If empty all the proxies are monitored -->
         <argument name="proxynames" is-required="false" default-value=""/>

--- a/src/main/resources/conf/monitor.xml
+++ b/src/main/resources/conf/monitor.xml
@@ -24,6 +24,8 @@
 
             <!--URI of the haproxy CSV stats url. See the 'CSV Export' link on your haproxy stats page -->
             <argument name="csv-export-uri" is-required="true" default-value=";csv"/>
+            <!--If the haproxy stats URI is SSL enabled, ie; HTTPS, use the below option -->
+            <argument name="use-ssl" is-required="false" default-value="false"/>
 
             <argument name="username" is-required="false" default-value=""/>
             <argument name="password" is-required="false" default-value=""/>


### PR DESCRIPTION
Hi,

Please review and accept this PR on readme update. This is essential for using HAProxy monitoring with SSL enabled Stats URI.

Had to go trace through the code to find out there is out of the box support but no documentation available on it.
The configuration has been tested successfully.